### PR TITLE
Added cglm as an external dependancy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,9 @@ project ("GPbase")
 # gl3w will need to be recompiled and added in order to generate this library again.
 # add_library (LoadShaders STATIC "src/LoadShaders.cpp")
 
+# Add extern subdir
+add_subdirectory(extern)
+
 # Add link director(y/ies) for libraries
 link_directories ("lib")
 
@@ -24,8 +27,8 @@ add_executable (GPbase "src/GPbase.c"  "include/GPbase.h" "include/LoadShaders.h
 
 # Add libraries to this project's executable.
 # Simply can specify the name of the library because CMake knows to look in the lib folder.
-target_link_libraries (GPbase glfw3 gl3wlib)
 
+target_link_libraries (GPbase glfw3 gl3wlib cglm)
 if (CMAKE_VERSION VERSION_GREATER 3.12)
   set_property(TARGET GPbase PROPERTY C_STANDARD 23)
 endif()

--- a/extern/CMakeLists.txt
+++ b/extern/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required (VERSION 3.8)
+
+include(FetchContent)
+
+# ---------------------------------------------------
+# CGLM
+
+FetchContent_Declare(
+	cglm
+
+	GIT_REPOSITORY https://github.com/recp/cglm.git
+)
+
+FetchContent_GetProperties(cglm)
+if (NOT cglm_POPULATED)
+	FetchContent_Populate(cglm)
+	add_subdirectory(
+	${cglm_SOURCE_DIR} 
+	${cglm_BINARY_DIR}
+	EXCLUDE_FROM_ALL)
+endif()

--- a/include/GPbase.h
+++ b/include/GPbase.h
@@ -13,6 +13,8 @@
 // Window creation library. Also handles other things like input.
 #include "GLFW/glfw3.h"
 
+#include "cglm/cglm.h"
+
 #include "LoadShaders.h"
 
 // Custom defines


### PR DESCRIPTION
Modifies CMakeLists.txt in the root directory to add extern as a subdirectory and cglm as a library.

Added rootdir/extern directory and added CMakeLists.txt into it.
CMakeLists.txt in extern loads cglm and allows it to be used by the root CMakeLists.txt.

